### PR TITLE
Add expressive monk icons and compact stats UI

### DIFF
--- a/images/monk_angry.svg
+++ b/images/monk_angry.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="18" r="12" fill="#f2d1b3" stroke="#333" stroke-width="2"/>
+  <path d="M20 30h24l8 26H12z" fill="#c49a6c" stroke="#333" stroke-width="2"/>
+  <path d="M18 30q14-10 28 0" fill="#a67c52" stroke="#333" stroke-width="2"/>
+  <path d="M26 14l4 -2" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+  <path d="M38 12l4 2" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="28" cy="16" r="2" fill="#333"/>
+  <circle cx="36" cy="16" r="2" fill="#333"/>
+  <path d="M26 24q6 -6 12 0" fill="none" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/images/monk_happy.svg
+++ b/images/monk_happy.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="18" r="12" fill="#f2d1b3" stroke="#333" stroke-width="2"/>
+  <path d="M20 30h24l8 26H12z" fill="#c49a6c" stroke="#333" stroke-width="2"/>
+  <path d="M18 30q14-10 28 0" fill="#a67c52" stroke="#333" stroke-width="2"/>
+  <circle cx="28" cy="16" r="2" fill="#333"/>
+  <circle cx="36" cy="16" r="2" fill="#333"/>
+  <path d="M26 22q6 6 12 0" fill="none" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/images/monk_neutral.svg
+++ b/images/monk_neutral.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="18" r="12" fill="#f2d1b3" stroke="#333" stroke-width="2"/>
+  <path d="M20 30h24l8 26H12z" fill="#c49a6c" stroke="#333" stroke-width="2"/>
+  <path d="M18 30q14-10 28 0" fill="#a67c52" stroke="#333" stroke-width="2"/>
+  <circle cx="28" cy="16" r="2" fill="#333"/>
+  <circle cx="36" cy="16" r="2" fill="#333"/>
+  <line x1="26" y1="22" x2="38" y2="22" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/images/monk_sad.svg
+++ b/images/monk_sad.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="18" r="12" fill="#f2d1b3" stroke="#333" stroke-width="2"/>
+  <path d="M20 30h24l8 26H12z" fill="#c49a6c" stroke="#333" stroke-width="2"/>
+  <path d="M18 30q14-10 28 0" fill="#a67c52" stroke="#333" stroke-width="2"/>
+  <circle cx="28" cy="16" r="2" fill="#333"/>
+  <circle cx="36" cy="16" r="2" fill="#333"/>
+  <path d="M26 24q6 -6 12 0" fill="none" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/images/monk_surprised.svg
+++ b/images/monk_surprised.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <circle cx="32" cy="18" r="12" fill="#f2d1b3" stroke="#333" stroke-width="2"/>
-  <path d="M20 30 h24 l8 26 h-40z" fill="#c49a6c" stroke="#333" stroke-width="2"/>
-  <path d="M18 30 q14-10 28 0" fill="#a67c52" stroke="#333" stroke-width="2"/>
+  <path d="M20 30h24l8 26H12z" fill="#c49a6c" stroke="#333" stroke-width="2"/>
+  <path d="M18 30q14-10 28 0" fill="#a67c52" stroke="#333" stroke-width="2"/>
   <circle cx="28" cy="16" r="2" fill="#333"/>
   <circle cx="36" cy="16" r="2" fill="#333"/>
-  <path d="M26 22 q6 6 12 0" fill="none" stroke="#333" stroke-width="2"/>
+  <circle cx="32" cy="23" r="3" fill="none" stroke="#333" stroke-width="2"/>
 </svg>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
     <div class="container">
         <header>
-            <img src="images/monk.svg" alt="僧侶" class="monk-icon">
+            <img src="images/monk_neutral.svg" alt="僧侶" class="monk-icon">
             <h1>⛩️ 住職のお悩み相談所 ⛩️</h1>
             <p>寺の住職として参拝者の悩みに答えましょう</p>
         </header>

--- a/script.js
+++ b/script.js
@@ -367,6 +367,7 @@ function initGame() {
     angerLevel = 50;
     emotionBalance = 0;
 
+    updateMonkExpression('neutral');
     updateDisplay();
     showConsultation();
 }
@@ -432,6 +433,14 @@ function updateEmotionBar() {
     }
 }
 
+// 僧侶の表情を切り替え
+function updateMonkExpression(expression) {
+    const monkIcon = document.querySelector('.monk-icon');
+    if (monkIcon) {
+        monkIcon.src = `images/monk_${expression}.svg`;
+    }
+}
+
 // 経験値を追加
 function addExperience(amount) {
     experience += amount;
@@ -447,9 +456,13 @@ function levelUp() {
     level++;
     experience -= experienceToNextLevel;
     experienceToNextLevel = Math.floor(experienceToNextLevel * 1.2); // 次のレベルに必要な経験値を増加
-    
+
     // レベルアップメッセージを表示
     showLevelUpMessage();
+    setTimeout(() => {
+        updateMonkExpression('surprised');
+        setTimeout(() => updateMonkExpression('happy'), 1500);
+    }, 0);
 }
 
 // レベルアップメッセージを表示
@@ -585,6 +598,8 @@ function selectAdvice(selectedIndex) {
         resultText.textContent = `✨ 素晴らしいアドバイスです！ +${pointsEarned}ポイント ✨`;
         resultMessage.textContent = consultation.successMessage;
         selectedAdviceElement.textContent = `あなた: ${consultation.advice[selectedIndex]}`;
+
+        updateMonkExpression('happy');
         
         // コンボメッセージ表示
         showComboMessage();
@@ -611,6 +626,12 @@ function selectAdvice(selectedIndex) {
         resultText.textContent = '😔 もう少し考えてみましょう... 😔';
         resultMessage.textContent = consultation.failureMessage;
         selectedAdviceElement.textContent = `あなた: ${consultation.advice[selectedIndex]}`;
+
+        if (angerLevel > 70) {
+            updateMonkExpression('angry');
+        } else {
+            updateMonkExpression('sad');
+        }
         
         // 失敗アニメーション
         resultElement.style.animation = 'failureShake 0.5s ease-out';
@@ -627,6 +648,8 @@ function selectAdvice(selectedIndex) {
 function nextConsultation() {
     currentConsultation++;
     remainingVisitors--;
+
+    updateMonkExpression('neutral');
 
     if (currentConsultation >= gameConsultations.length) {
         // ゲーム終了

--- a/style.css
+++ b/style.css
@@ -82,36 +82,38 @@ header p {
 
 /* 統計情報コンテナ */
 .stats-container {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 10px;
-  margin-bottom: 20px;
-  padding: 15px;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+  padding: 10px;
   background: #f8fafc;
   border-radius: 10px;
   border: 2px solid #e2e8f0;
+  overflow-x: auto;
 }
 
 .stat-item {
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 8px;
+  padding: 6px;
   background: white;
   border-radius: 8px;
   border: 1px solid #e2e8f0;
+  min-width: 80px;
 }
 
 .stat-label {
-  font-size: 0.8em;
+  font-size: 0.75em;
   color: #666;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
   font-weight: bold;
 }
 
 .stat-value {
-  font-size: 1.1em;
+  font-size: 1em;
   font-weight: bold;
   color: #4a5568;
 }
@@ -476,21 +478,21 @@ header p {
   }
   
   .stats-container {
-      grid-template-columns: repeat(2, 1fr);
-      gap: 8px;
-      padding: 10px;
+      gap: 6px;
+      padding: 8px;
   }
-  
+
   .stat-item {
-      padding: 6px;
+      padding: 4px;
+      min-width: 70px;
   }
-  
+
   .stat-label {
       font-size: 0.7em;
   }
-  
+
   .stat-value {
-      font-size: 1em;
+      font-size: 0.9em;
   }
   
   .emotion-bar {


### PR DESCRIPTION
## Summary
- Replace the old monk graphic with five SVG icons (neutral, happy, sad, angry, surprised) and switch them based on game events.
- Tighten statistics panel spacing and make it horizontally scrollable for better visibility on mobile.

## Testing
- `node --check script.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b69e824a483308e8488d048a050ed