### PR TITLE
Double failure advice length

### DIFF
--- a/script.js
+++ b/script.js
@@ -624,7 +624,7 @@ function selectAdvice(selectedIndex) {
         resultElement.className = 'result failure';
         document.getElementById('visitor-img').src = `images/${currentVisitorType}_sad.svg`;
         resultText.textContent = '😔 もう少し考えてみましょう... 😔';
-        resultMessage.textContent = consultation.failureMessage;
+        resultMessage.textContent = `${consultation.failureMessage} ${consultation.failureMessage}`;
         selectedAdviceElement.textContent = `あなた: ${consultation.advice[selectedIndex]}`;
 
         if (angerLevel > 70) {


### PR DESCRIPTION
## Summary
- Repeat failure messages to double text shown for incorrect answers

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688da168fe588330af9af1e90a698533