### PR TITLE
fix: delay game initialization until DOM is ready

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,32 +1,36 @@
-const deck = ['坊主', '殿', '殿', '殿', '殿', '殿', '殿', '殿', '殿', '殿'];
-let score = 0;
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    const deck = ['坊主', '殿', '殿', '殿', '殿', '殿', '殿', '殿', '殿', '殿'];
+    let score = 0;
 
-const message = document.getElementById('message');
-const remaining = document.getElementById('remaining');
-const scoreEl = document.getElementById('score');
-const drawBtn = document.getElementById('draw');
+    const message = document.getElementById('message');
+    const remaining = document.getElementById('remaining');
+    const scoreEl = document.getElementById('score');
+    const drawBtn = document.getElementById('draw');
 
-function updateDisplay() {
-  remaining.textContent = `残り枚数: ${deck.length}`;
-  scoreEl.textContent = `得点: ${score}`;
-}
-
-drawBtn.addEventListener('click', () => {
-  const index = Math.floor(Math.random() * deck.length);
-  const card = deck.splice(index, 1)[0];
-
-  if (card === '坊主') {
-    message.textContent = '坊主！ゲーム終了';
-    drawBtn.disabled = true;
-  } else {
-    score++;
-    message.textContent = `${card}を引きました`;
-    if (deck.length === 0) {
-      message.textContent = 'すべての札をめくりました。勝利！';
-      drawBtn.disabled = true;
+    function updateDisplay() {
+      remaining.textContent = `残り枚数: ${deck.length}`;
+      scoreEl.textContent = `得点: ${score}`;
     }
-  }
-  updateDisplay();
-});
 
-updateDisplay();
+    drawBtn.addEventListener('click', () => {
+      const index = Math.floor(Math.random() * deck.length);
+      const card = deck.splice(index, 1)[0];
+
+      if (card === '坊主') {
+        message.textContent = '坊主！ゲーム終了';
+        drawBtn.disabled = true;
+      } else {
+        score++;
+        message.textContent = `${card}を引きました`;
+        if (deck.length === 0) {
+          message.textContent = 'すべての札をめくりました。勝利！';
+          drawBtn.disabled = true;
+        }
+      }
+      updateDisplay();
+    });
+
+    updateDisplay();
+  });
+}


### PR DESCRIPTION
## Summary
- Guard browser-specific code and wait for DOMContentLoaded before initializing game
- Prevent crashes when DOM is unavailable

## Testing
- `node script.js`


------
https://chatgpt.com/codex/tasks/task_e_688ee1c8b1e08330b24d5cde20bd1ea5