### PR TITLE
Adjust card layout for mobile and add audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,17 +1,19 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta charset="UTF-8">
-<title>坊主めくり</title>
-<link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>坊主めくり</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<h1>坊主めくり</h1>
-<div id="message">カードをめくってください</div>
-<img id="card-image" alt="カードの画像" style="display:none" />
-<div id="remaining"></div>
-<div id="score"></div>
-<button id="draw">カードをめくる</button>
-<script src="script.js"></script>
+  <h1>坊主めくり</h1>
+  <audio id="bgm" src="audio/BGM.mp3" loop></audio>
+  <div id="message">カードをめくってください</div>
+  <img id="card-image" alt="カードの画像" style="display:none" />
+  <div id="remaining"></div>
+  <div id="score"></div>
+  <button id="draw">カードをめくる</button>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -9,9 +9,7 @@ if (typeof document !== 'undefined') {
     const scoreEl = document.getElementById('score');
     const drawBtn = document.getElementById('draw');
 
-    const bgm = new Audio('audio/BGM.mp3');
-    bgm.loop = true;
-    bgm.play();
+    const bgm = document.getElementById('bgm');
 
     const flipSound = new Audio('audio/mekuru.mp3');
     const bouzuSound = new Audio('audio/bouzu.mp3');
@@ -24,6 +22,9 @@ if (typeof document !== 'undefined') {
     }
 
     drawBtn.addEventListener('click', () => {
+      if (bgm.paused) {
+        bgm.play();
+      }
       flipSound.currentTime = 0;
       flipSound.play();
 

--- a/style.css
+++ b/style.css
@@ -14,3 +14,9 @@ button {
   margin: 20px 0;
   font-size: 1.2em;
 }
+
+#card-image {
+  width: 25%;
+  height: auto;
+  max-width: 100%;
+}


### PR DESCRIPTION
## Summary
- Resize card image to 25% width and ensure mobile-friendly layout via viewport meta tag
- Embed looping background music element and start playback after user interaction
- Style updates for responsive card display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68908b5294748330a67c3c37b8d75a22