### PR TITLE
feat: display card stacks for each player

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
   <audio id="bgm" src="audio/BGM.mp3" loop></audio>
   <div id="message">カードをめくってください</div>
   <img id="card-image" alt="カードの画像" style="display:none" />
+  <div id="cpu-pile" class="pile"></div>
+  <div id="player-pile" class="pile"></div>
   <div id="remaining"></div>
   <div id="counts">
     <span id="player-count"></span>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,8 @@ if (typeof document !== 'undefined') {
     const remaining = document.getElementById('remaining');
     const playerCountEl = document.getElementById('player-count');
     const cpuCountEl = document.getElementById('cpu-count');
+    const playerPile = document.getElementById('player-pile');
+    const cpuPile = document.getElementById('cpu-pile');
     const drawBtn = document.getElementById('draw');
 
     const bgm = document.getElementById('bgm');
@@ -55,12 +57,14 @@ if (typeof document !== 'undefined') {
       cardImage.style.display = 'block';
 
       const pile = current === 'player' ? playerCards : cpuCards;
+      const pileContainer = current === 'player' ? playerPile : cpuPile;
 
       if (card === '坊主') {
         bouzuSound.play();
         message.textContent = current === 'player' ? '坊主！カードを山札に戻します' : 'CPUが坊主！カードを山札に戻します';
         deck.push(...pile, card);
         pile.length = 0;
+        pileContainer.innerHTML = '';
         shuffle(deck);
       } else {
         if (card === '姫') {
@@ -69,6 +73,11 @@ if (typeof document !== 'undefined') {
           tonoSound.play();
         }
         pile.push(card);
+        const cardElem = document.createElement('img');
+        cardElem.src = images[card];
+        cardElem.classList.add('pile-card');
+        cardElem.style.left = `${(pile.length - 1) * 20}px`;
+        pileContainer.appendChild(cardElem);
         message.textContent = current === 'player' ? `${card}を引きました` : `CPUが${card}を引きました`;
       }
 

--- a/style.css
+++ b/style.css
@@ -29,3 +29,24 @@ button {
 #counts span {
   margin: 0 10px;
 }
+
+.pile {
+  position: relative;
+  width: 220px;
+  height: 100px;
+  margin: 20px auto;
+}
+
+#cpu-pile {
+  margin-bottom: -80px;
+}
+
+.pile-card {
+  width: 60px;
+  position: absolute;
+  top: 0;
+}
+
+#player-pile .pile-card {
+  top: 20px;
+}


### PR DESCRIPTION
## Summary
- show CPU and player piles with overlapping card images
- style card piles so player stack appears in front of CPU stack
- update draw logic to add or clear card images on each draw

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891c8434e908330b603e3cb986a77de