### PR TITLE
feat: improve bozu gameplay and ui

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,11 +8,17 @@
 </head>
 <body>
   <h1>坊主めくり</h1>
+  <details id="rules">
+    <summary>遊び方 / How to Play</summary>
+    <p>カードをめくり姫と殿を集めましょう。坊主を引くと集めたカードをすべて失います。最終的に多く集めた方が勝ちです。</p>
+  </details>
   <audio id="bgm" src="audio/BGM.mp3" loop></audio>
   <div id="message">カードをめくってください</div>
   <img id="card-image" alt="カードの画像" style="display:none" />
-  <div id="cpu-pile" class="pile"></div>
-  <div id="player-pile" class="pile"></div>
+  <div id="piles" class="piles">
+    <div id="cpu-pile" class="pile"></div>
+    <div id="player-pile" class="pile"></div>
+  </div>
   <div id="remaining"></div>
   <div id="counts">
     <span id="player-count"></span>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,5 @@
 if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', () => {
-    const deck = ['坊主', '姫', '殿', '殿', '殿', '殿', '殿', '殿', '殿', '殿'];
-
     const message = document.getElementById('message');
     const cardImage = document.getElementById('card-image');
     const remaining = document.getElementById('remaining');
@@ -18,6 +16,19 @@ if (typeof document !== 'undefined') {
     const himeSound = new Audio('audio/hime.mp3');
     const tonoSound = new Audio('audio/otoko.mp3');
 
+    const cardTypes = {
+      bozu: { label: '坊主', image: 'images/monk.png', sound: bouzuSound, consequence: 'カードをすべて失います' },
+      hime: { label: '姫', image: 'images/princess.png', sound: himeSound, consequence: '1枚獲得' },
+      danna: { label: '殿', image: 'images/nobleman.png', sound: tonoSound, consequence: '1枚獲得' }
+    };
+
+    const deck = [
+      { type: 'bozu' },
+      { type: 'hime' },
+      { type: 'danna' }, { type: 'danna' }, { type: 'danna' }, { type: 'danna' },
+      { type: 'danna' }, { type: 'danna' }, { type: 'danna' }, { type: 'danna' }
+    ];
+
     const playerCards = [];
     const cpuCards = [];
     let turn = 'player';
@@ -25,6 +36,8 @@ if (typeof document !== 'undefined') {
     function shuffle(array) {
       array.sort(() => Math.random() - 0.5);
     }
+
+    shuffle(deck);
 
     function updateDisplay() {
       remaining.textContent = `残り枚数: ${deck.length}`;
@@ -47,38 +60,32 @@ if (typeof document !== 'undefined') {
 
       const index = Math.floor(Math.random() * deck.length);
       const card = deck.splice(index, 1)[0];
-
-      const images = {
-        '坊主': 'images/monk.png',
-        '姫': 'images/princess.png',
-        '殿': 'images/nobleman.png'
-      };
-      cardImage.src = images[card];
+      const info = cardTypes[card.type];
+      cardImage.src = info.image;
       cardImage.style.display = 'block';
 
       const pile = current === 'player' ? playerCards : cpuCards;
       const pileContainer = current === 'player' ? playerPile : cpuPile;
 
-      if (card === '坊主') {
-        bouzuSound.play();
-        message.textContent = current === 'player' ? '坊主！カードを山札に戻します' : 'CPUが坊主！カードを山札に戻します';
-        deck.push(...pile, card);
+      if (card.type === 'bozu') {
+        info.sound.play();
+        message.innerHTML = current === 'player'
+          ? '坊主を引きました！<br>カードをすべて失います。'
+          : 'CPUが坊主を引きました！<br>CPUはカードをすべて失います。';
         pile.length = 0;
         pileContainer.innerHTML = '';
-        shuffle(deck);
+        document.body.classList.add('shake');
+        setTimeout(() => document.body.classList.remove('shake'), 500);
       } else {
-        if (card === '姫') {
-          himeSound.play();
-        } else {
-          tonoSound.play();
-        }
+        info.sound.play();
         pile.push(card);
         const cardElem = document.createElement('img');
-        cardElem.src = images[card];
+        cardElem.src = info.image;
         cardElem.classList.add('pile-card');
         cardElem.style.left = `${(pile.length - 1) * 20}px`;
         pileContainer.appendChild(cardElem);
-        message.textContent = current === 'player' ? `${card}を引きました` : `CPUが${card}を引きました`;
+        const who = current === 'player' ? 'あなた' : 'CPU';
+        message.innerHTML = `${who}は${info.label}を引きました！<br>${info.consequence}`;
       }
 
       updateDisplay();

--- a/style.css
+++ b/style.css
@@ -10,15 +10,28 @@ button {
   font-size: 1.2em;
 }
 
+#draw {
+  background: #f0e68c;
+  border: 2px solid #8b4513;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+#draw:hover {
+  background: #fff8dc;
+}
+
 #message {
   margin: 20px 0;
   font-size: 1.2em;
 }
 
 #card-image {
-  width: 50%;
-  height: auto;
+  width: auto;
   max-width: 100%;
+  height: auto;
+  max-height: 400px;
 }
 
 #counts {
@@ -30,11 +43,18 @@ button {
   margin: 0 10px;
 }
 
+.piles {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .pile {
   position: relative;
   width: 220px;
   height: 100px;
-  margin: 20px auto;
+  margin: 20px;
 }
 
 #cpu-pile {
@@ -49,4 +69,31 @@ button {
 
 #player-pile .pile-card {
   top: 20px;
+}
+
+#rules {
+  max-width: 400px;
+  margin: 0 auto 20px;
+  text-align: left;
+}
+
+body.shake {
+  animation: shake 0.5s;
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20%, 60% { transform: translateX(-10px); }
+  40%, 80% { transform: translateX(10px); }
+}
+
+@media (max-width: 600px) {
+  .piles {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  #card-image {
+    width: 80%;
+  }
 }


### PR DESCRIPTION
## Summary
- reset player or CPU card counts when drawing a Bozu and give immediate feedback
- classify cards through a mapping and show card type and consequence after each draw
- polish UI with instructions, responsive layout, card-size limit and highlighted draw button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689342f827d48330873642bc0813c314