### PR TITLE
Remove top card display

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
   </details>
   <audio id="bgm" src="audio/BGM.mp3" loop></audio>
   <div id="message">カードをめくってください</div>
-  <img id="card-image" alt="カードの画像" style="display:none" />
   <div id="piles" class="piles">
     <div id="cpu-pile" class="pile"></div>
     <div id="player-pile" class="pile"></div>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,6 @@
 if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', () => {
     const message = document.getElementById('message');
-    const cardImage = document.getElementById('card-image');
     const remaining = document.getElementById('remaining');
     const playerPile = document.getElementById('player-pile');
     const cpuPile = document.getElementById('cpu-pile');
@@ -57,10 +56,6 @@ if (typeof document !== 'undefined') {
       const index = Math.floor(Math.random() * deck.length);
       const card = deck.splice(index, 1)[0];
       const info = cardTypes[card.type];
-      cardImage.src = info.image;
-      cardImage.style.display = 'block';
-      cardImage.className = '';
-      cardImage.classList.add(`card-${card.type}`);
 
       const pile = current === 'player' ? playerCards : cpuCards;
       const pileContainer = current === 'player' ? playerPile : cpuPile;

--- a/style.css
+++ b/style.css
@@ -27,14 +27,8 @@ button {
   font-size: 1.2em;
 }
 
-#card-image {
-  width: auto;
-  max-width: 100%;
-  height: auto;
-  max-height: 400px;
-}
 
-#card-image, .pile-card {
+.pile-card {
   box-sizing: border-box;
 }
 
@@ -105,7 +99,4 @@ body.shake {
     align-items: center;
   }
 
-  #card-image {
-    width: 80%;
-  }
 }


### PR DESCRIPTION
## Summary
- stop rendering the large top card preview and remove its CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896c87c4b408330837e0335b99f8257