### PR TITLE
feat: add flashy Japanese victory effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@
   <div id="remaining"></div>
   <div id="scoreboard">Player: 0 cards<br>CPU: 0 cards</div>
   <button id="draw-button">カードをめくる</button>
+  <div id="victory-overlay">
+    <div id="victory-text">勝利！</div>
+  </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -40,10 +40,30 @@ if (typeof document !== 'undefined') {
       scoreboard.innerHTML = `Player: ${playerCards.length} cards<br>CPU: ${cpuCards.length} cards`;
     }
 
+    function showVictory() {
+      const overlay = document.getElementById('victory-overlay');
+      overlay.classList.add('show');
+      for (let i = 0; i < 30; i++) {
+        const petal = document.createElement('div');
+        petal.textContent = '🌸';
+        petal.className = 'sakura';
+        petal.style.left = `${Math.random() * 100}vw`;
+        petal.style.animationDelay = `${Math.random() * 5}s`;
+        overlay.appendChild(petal);
+      }
+    }
+
+    function endGame() {
+      message.textContent = `すべての札をめくりました。プレイヤー: ${playerCards.length}枚 CPU: ${cpuCards.length}枚`;
+      drawBtn.disabled = true;
+      if (playerCards.length > cpuCards.length) {
+        showVictory();
+      }
+    }
+
     function drawCard(current) {
       if (deck.length === 0) {
-        message.textContent = `すべての札をめくりました。プレイヤー: ${playerCards.length}枚 CPU: ${cpuCards.length}枚`;
-        drawBtn.disabled = true;
+        endGame();
         return;
       }
 
@@ -84,8 +104,7 @@ if (typeof document !== 'undefined') {
       updateDisplay();
 
       if (deck.length === 0) {
-        message.textContent = `すべての札をめくりました。プレイヤー: ${playerCards.length}枚 CPU: ${cpuCards.length}枚`;
-        drawBtn.disabled = true;
+        endGame();
       }
     }
 

--- a/style.css
+++ b/style.css
@@ -100,3 +100,50 @@ body.shake {
   }
 
 }
+
+#victory-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 215, 0, 0.9);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  opacity: 0;
+  pointer-events: none;
+  overflow: hidden;
+  transition: opacity 0.5s;
+}
+
+#victory-overlay.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#victory-text {
+  font-size: 4em;
+  color: #b22222;
+  text-shadow: 0 0 10px #ffd700, 0 0 20px #ffd700;
+  animation: victory-pulse 1s infinite;
+}
+
+@keyframes victory-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.2); }
+}
+
+.sakura {
+  position: absolute;
+  top: -50px;
+  font-size: 24px;
+  animation: fall 5s linear infinite;
+}
+
+@keyframes fall {
+  0% { transform: translateY(0) rotate(0deg); opacity: 1; }
+  100% { transform: translateY(110vh) rotate(360deg); opacity: 0; }
+}


### PR DESCRIPTION
## Summary
- show victory overlay with bold kanji and sakura petals
- style victory screen with gold background and animations
- reveal overlay when player wins

## Testing
- `npm test` *(fails: enoent package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6896f2ddb8808330858dd88fecb66e3d